### PR TITLE
Modify the content of email for experiment status change

### DIFF
--- a/experiments/views.py
+++ b/experiments/views.py
@@ -199,18 +199,20 @@ def experiment_update_by_ops(request, experiment_uuid):
             experiment_uuid = update_existing_experiment(request, experiment, form, prev_stage,
                                                          prev_state)
             if experiment.message is not None and experiment.message != "":
-                subject = 'DISCOVER Experiment Notification: {}'.format(experiment.uuid)
-                email_message = "[{}]\n\n".format(subject) \
-                                + "Experiment Name: {}\n".format(str(experiment)) \
+                subject = 'DISCOVER Experiment Notification: {}'.format(str(experiment))
+                email_message = "Experiment {} has been updated to new stage\n\n".format(str(experiment)) \
+                                + "Experiment ID: {}\n".format(experiment.uuid) \
                                 + "Project: {}\n\n".format(experiment.project) \
                                 + "Notification/Message:\n{}\n".format(experiment.message)
                 receivers = [experimenter]
+                reference_url = 'https://' + str(request.get_host()) \
+                            + '/experiments/{}'.format(experiment.uuid)
                 logger.warning("send_email:\n" + subject)
                 logger.warning(email_message)
                 logger.warning("receivers = {}\n".format(receivers))
                 portal_mail(subject=subject, body_message=email_message, sender=request.user,
                             receivers=receivers,
-                            reference_note=None, reference_url=None)
+                            reference_note=None, reference_url=reference_url)
 
             return redirect('experiment_detail', experiment_uuid=str(experiment.uuid))
 


### PR DESCRIPTION
Issue: https://github.com/DiscoverCCRI/portal_v1/issues/22
I modified the content of the email for the experiment status change and add the space for comment (image attached below).

![image](https://github.com/DiscoverCCRI/portal_v1/assets/37945098/e61871e1-b9e7-47c3-8135-02b91da769e5)
